### PR TITLE
Delete Confirmation Modal

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,7 +1,4 @@
-import { deleteTodo } from "./todos";
-
-let deleteTargetId: number | null = null;
-let listRef: HTMLUListElement | null = null;
+let onConfirmCallback: (() => void) | null = null;
 
 // Create Modal DOM Elements
 const modalContainer = document.createElement("div");
@@ -32,21 +29,19 @@ modalContainer.appendChild(modal);
 document.body.appendChild(modalContainer);
 
 // Show-Hide functions
-export function showDeleteModal(todoId: number, list: HTMLUListElement): void {
-    deleteTargetId = todoId;
-    listRef = list;
+export function showDeleteModal(onConfirm: () => void): void {
+    onConfirmCallback = onConfirm;
     modalContainer.classList.remove("hidden");
 }
 
 export function hideDeleteModal(): void {
     modalContainer.classList.add("hidden");
-    deleteTargetId = null;
-    listRef = null;
+    onConfirmCallback = null;
 }
 
 confirmBtn.addEventListener("click", () => {
-    if (deleteTargetId !== null && listRef) {
-        deleteTodo(deleteTargetId, listRef);
+    if (onConfirmCallback) {
+        onConfirmCallback();
     }
     hideDeleteModal();
 });

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,4 +1,6 @@
-let deleteTargetId: string | null = null;
+import { deleteTodo } from "./todos";
+
+let deleteTargetId: number | null = null;
 let listRef: HTMLUListElement | null = null;
 
 // Create Modal DOM Elements
@@ -29,3 +31,34 @@ modal.appendChild(actions);
 modalContainer.appendChild(modal);
 document.body.appendChild(modalContainer);
 
+// Show-Hide functions
+export function showDeleteModal(todoId: number, list: HTMLUListElement): void {
+    deleteTargetId = todoId;
+    listRef = list;
+    modalContainer.classList.remove("hidden");
+}
+
+export function hideDeleteModal(): void {
+    modalContainer.classList.add("hidden");
+    deleteTargetId = null;
+    listRef = null;
+}
+
+confirmBtn.addEventListener("click", () => {
+    if (deleteTargetId !== null && listRef) {
+        deleteTodo(deleteTargetId, listRef);
+    }
+    hideDeleteModal();
+});
+
+cancelBtn.addEventListener("click", hideDeleteModal);
+
+modalContainer.addEventListener("click", (e) => {
+    if (e.target === modalContainer) hideDeleteModal();
+});
+
+document.addEventListener("keydown", (e) => {
+    if (!modalContainer.classList.contains("hidden") && e.key === "Escape") {
+      hideDeleteModal();
+    }
+});

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,0 +1,31 @@
+let deleteTargetId: string | null = null;
+let listRef: HTMLUListElement | null = null;
+
+// Create Modal DOM Elements
+const modalContainer = document.createElement("div");
+modalContainer.className = "modal-container hidden";
+
+const modal = document.createElement("div");
+modal.className = "modal";
+
+const message = document.createElement("p");
+message.textContent = "Are you sure you want to delete this task?";
+
+const actions = document.createElement("div");
+actions.className = "modal-actions";
+
+const confirmBtn = document.createElement("button");
+confirmBtn.className = "confirm-btn";
+confirmBtn.textContent = "Delete";
+
+const cancelBtn = document.createElement("button");
+cancelBtn.className = "cancel-btn";
+cancelBtn.textContent = "Cancel";
+
+actions.appendChild(confirmBtn);
+actions.appendChild(cancelBtn);
+modal.appendChild(message);
+modal.appendChild(actions);
+modalContainer.appendChild(modal);
+document.body.appendChild(modalContainer);
+

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -1,4 +1,5 @@
 let onConfirmCallback: (() => void) | null = null;
+let previouslyFocusedElement: HTMLElement | null = null;
 
 // Create Modal DOM Elements
 const modalContainer = document.createElement("div");
@@ -31,12 +32,19 @@ document.body.appendChild(modalContainer);
 // Show-Hide functions
 export function showDeleteModal(onConfirm: () => void): void {
     onConfirmCallback = onConfirm;
+    previouslyFocusedElement = document.activeElement as HTMLElement;
     modalContainer.classList.remove("hidden");
+    confirmBtn.focus();
 }
 
 export function hideDeleteModal(): void {
     modalContainer.classList.add("hidden");
     onConfirmCallback = null;
+
+    if (previouslyFocusedElement) {
+        previouslyFocusedElement.focus();
+        previouslyFocusedElement = null;
+    }
 }
 
 confirmBtn.addEventListener("click", () => {

--- a/src/render.ts
+++ b/src/render.ts
@@ -2,6 +2,7 @@ import { todos, currentFilter } from "./state.js";
 import { Filter, type Todo } from "./types.js";
 import { toggleTodo, deleteTodo, editTodo } from "./todos.js";
 import { handleEdit } from "./handleEdit.js";
+import { showDeleteModal } from "./modal.js";
 
 // Rendering Todos
 export function renderTodos(list: HTMLUListElement) {
@@ -33,7 +34,9 @@ export function renderTodos(list: HTMLUListElement) {
         const deleteBtn = document.createElement("button");
         deleteBtn.className = "todo-delete-btn";
         deleteBtn.textContent = "DELETE";
-        deleteBtn.addEventListener("click", () => deleteTodo(todo.id, list));
+        deleteBtn.addEventListener("click", () => {
+            showDeleteModal(() => deleteTodo(todo.id, list))
+        });
 
         const editBtn = document.createElement("button");
         editBtn.className = "todo-edit-btn";

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,3 +1,20 @@
+:root {
+    --text-color: #333;
+    --text-white: #fff;
+    --button-green: #4caf50;
+    --button-green-hover: #2f8532;
+    --button-gray: #9e9e9e;
+    --button-gray-hover: #757575;
+    --button-red: #e53935;
+    --button-red-hover: #c62828;
+    --border-radius-sm: 4px;
+    --border-radius-md: 6px;
+    --border-radius-lg: 10px;
+    --padding-sm: 0.4rem 0.6rem;
+    --padding-md: 0.6rem 1rem;
+    --transition-fast: 0.2s ease; 
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -7,7 +24,7 @@
 body {
     font-family: system-ui, -apple-system, sans-serif;
     background-color: #a7d7e7;
-    color: #333;
+    color: var(--text-color);
     padding: 2rem;
     display: flex;
     flex-direction: column;
@@ -17,7 +34,7 @@ body {
 .app-title {
     text-align: center;
     margin-bottom: 1rem;
-    color: #222;
+    color: var(--text-color);
 }
 
 .todo-form {
@@ -37,17 +54,17 @@ body {
 }
 
 .add-btn {
-    background-color: #4caf50;
-    color: white;
+    background-color: var(--button-green);
+    color: var(--text-white);
     border: none;
-    padding: 0.6rem 1rem;
-    border-radius: 6px;
+    padding: var(--padding-md);
+    border-radius: var(--border-radius-md);
     cursor: pointer;
-    transition: background-color 0.2s ease;
+    transition: background-color var(--transition-fast);
 }
 
 .add-btn:hover {
-    background-color: #2f8532;
+    background-color: var(--button-green-hover);
 }
 
 .filter-container {
@@ -71,8 +88,8 @@ body {
 }
 
 .filter-button.active-filter {
-    background-color: #4caf50;
-    color: white;
+    background-color: var(--button-green);
+    color: var(--text-white);
 }
 
 .todo-list {
@@ -85,7 +102,7 @@ body {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    background: white;
+    background: var(--text-white);
     padding: 0.5rem;
     border: 1px solid #ddd;
     margin-bottom: 0.5rem;
@@ -109,21 +126,21 @@ body {
 }
 
 .todo-delete-btn {
-    background: #e53935;
-    color: white;
-    padding: 0.4rem 0.6rem;
+    background: var(--button-red);
+    color: var(--text-white);
+    padding: var(--padding-sm);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius-sm);
     cursor: pointer;
 }
 
 .todo-delete-btn:hover {
-    background-color: #c62828;
+    background-color: var(--button-red-hover);
 }
   
 .todo-edit-btn {
     background: #1976d2;
-    color: white;
+    color: var(--text-white);
     padding: 0.4rem 0.6rem;
     border: none;
     border-radius: 4px;
@@ -144,29 +161,29 @@ body {
 }
 
 .todo-save-btn {
-    background-color: #4caf50;
-    color: white;
-    padding: 0.4rem 0.6rem;
+    background-color: var(--button-green);
+    color: var(--text-white);
+    padding: var(--padding-sm);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius-sm);
     cursor: pointer;
 }
   
 .todo-save-btn:hover {
-    background-color: #43a047;
+    background-color: var(--button-green-hover);
 }
   
 .todo-cancel-btn {
-    background-color: #9e9e9e;
-    color: white;
-    padding: 0.4rem 0.6rem;
+    background-color: var(--button-gray);
+    color: var(--text-white);
+    padding: var(--padding-sm);
     border: none;
-    border-radius: 4px;
+    border-radius: var(--border-radius-sm);
     cursor: pointer;
 }
   
 .todo-cancel-btn:hover {
-    background-color: #757575;
+    background-color: var(--button-gray-hover);
 }
 
 /* Modal */
@@ -184,19 +201,19 @@ body {
 }
 
 .modal {
-    background: #fff;
+    background: var(--text-white);
     padding: 1.5rem 2rem;
-    border-radius: 10px;
+    border-radius: var(--border-radius-lg);
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
     max-width: 350px;
     width: 100%;
     text-align: center;
-    animation: modal-pop 0.2s ease-out;
+    animation: modal-pop var(--transition-fast);
 }
 
 .modal p {
     font-size: 1rem;
-    color: #333;
+    color: var(--text-color);
     margin-bottom: 1rem;
 }
 
@@ -207,33 +224,33 @@ body {
 }
 
 .confirm-btn {
-    background-color: #e74c3c;
-    color: #fff;
+    background-color: var(--button-red);
+    color: var(--text-white);
     border: none;
-    padding: 0.6rem 1rem;
-    border-radius: 6px;
+    padding: var(--padding-md);
+    border-radius: var(--border-radius-md);
     cursor: pointer;
     font-size: 0.9rem;
-    transition: background 0.2s ease;
+    transition: background var(--transition-fast);
 }
 
 .confirm-btn:hover {
-    background-color: #c0392b;
+    background-color: var(--button-red-hover);
 }
 
 .cancel-btn {
-    background-color: #bdc3c7;
-    color: #333;
+    background-color: var(--button-gray);
+    color: var(--text-white);
     border: none;
-    padding: 0.6rem 1rem;
-    border-radius: 6px;
+    padding: var(--padding-md);
+    border-radius: var(--border-radius-md);
     cursor: pointer;
     font-size: 0.9rem;
-    transition: background 0.2s ease;
+    transition: background var(--transition-fast);
 }
   
 .cancel-btn:hover {
-    background-color: #95a5a6;
+    background-color: var(--button-gray-hover);
 }
 
 .hidden {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -169,6 +169,84 @@ body {
     background-color: #757575;
 }
 
+/* Modal */
+.modal-container {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal {
+    background: #fff;
+    padding: 1.5rem 2rem;
+    border-radius: 10px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    max-width: 350px;
+    width: 100%;
+    text-align: center;
+    animation: modal-pop 0.2s ease-out;
+}
+
+.modal p {
+    font-size: 1rem;
+    color: #333;
+    margin-bottom: 1rem;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.confirm-btn {
+    background-color: #e74c3c;
+    color: #fff;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.2s ease;
+}
+
+.confirm-btn:hover {
+    background-color: #c0392b;
+}
+
+.cancel-btn {
+    background-color: #bdc3c7;
+    color: #333;
+    border: none;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: background 0.2s ease;
+}
+  
+.cancel-btn:hover {
+    background-color: #95a5a6;
+}
+
 .hidden {
     display: none;
+}
+
+@keyframes modal-pop {
+    from {
+      transform: scale(0.95);
+      opacity: 0;
+    }
+    to {
+      transform: scale(1);
+      opacity: 1;
+    }
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -168,4 +168,7 @@ body {
 .todo-cancel-btn:hover {
     background-color: #757575;
 }
-  
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
- Added modal.ts to handle the delete confirmation modal
- Modal shows on clicking “DELETE” and can be dismissed via: confirm, cancel, clicking outside, or the Escape key
- Updated render.ts to use showDeleteModal instead of directly deleting todos
- Added CSS classes for modal styling: .modal-container, .modal, .modal-actions, .confirm-btn, .cancel-btn
- Ensured modal appearance matches app layout (overlay, buttons, rounded corners, shadows)
- Fixed TypeScript compilation paths and preserved separation of concerns
- Improved UX by preventing accidental todo deletions